### PR TITLE
bashrc: remove exported color vars

### DIFF
--- a/files/.bashrc.dotfiles
+++ b/files/.bashrc.dotfiles
@@ -32,16 +32,6 @@ fi
 # TERM setup
 export CLICOLOR=1
 export TERM="xterm-256color"
-# colors
-export BLACK="\\033[0;30m"
-export RED="\\033[0;31m"
-export GREEN="\\033[0;32m"
-export YELLOW="\\033[0;33m"
-export BLUE="\\033[0;34m"
-export MAGENTA="\\033[0;35m"
-export CYAN="\\033[0;36m"
-export WHITE="\\033[0;37m"
-export PLAIN="\\033[m"
 
 # bash history
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)


### PR DESCRIPTION
these are holdovers from before I used starship for my PS1.